### PR TITLE
add track number in filename

### DIFF
--- a/src/services/__tests__/spotify.test.js
+++ b/src/services/__tests__/spotify.test.js
@@ -39,10 +39,10 @@ describe("spotify.js services", () => {
       assert.strictEqual(result.name, "My Awesome Playlist");
       assert.strictEqual(result.folderName, "My Awesome Playlist");
       assert.strictEqual(result.tracks.length, 2);
-      assert.strictEqual(result.tracks[0].fullTitle, "Artist 1 - Track 1");
+      assert.strictEqual(result.tracks[0].fullTitle, "1. Artist 1 - Track 1");
       assert.strictEqual(
         result.tracks[1].fullTitle,
-        "Artist 2, Artist 3 - Track 2"
+        "2. Artist 2, Artist 3 - Track 2"
       );
 
       // Verify that the mocks were called correctly
@@ -85,11 +85,11 @@ describe("spotify.js services", () => {
       assert.strictEqual(result.tracks.length, 2);
       assert.strictEqual(
         result.tracks[0].fullTitle,
-        "Queen - Bohemian Rhapsody"
+        "1. Queen - Bohemian Rhapsody"
       );
       assert.strictEqual(
         result.tracks[1].fullTitle,
-        "Queen - We Will Rock You"
+        "2. Queen - We Will Rock You"
       );
     });
 
@@ -118,7 +118,7 @@ describe("spotify.js services", () => {
       assert.strictEqual(result.tracks.length, 1);
       assert.strictEqual(
         result.tracks[0].fullTitle,
-        "Queen, David Bowie - Under Pressure"
+        "1. Queen, David Bowie - Under Pressure"
       );
     });
 

--- a/src/services/spotify.js
+++ b/src/services/spotify.js
@@ -1,7 +1,7 @@
 import * as spotifyApi from "../api/spotify/spotify.js";
 import { getArtists } from "../utils/spotify.js";
 
-function enrichTrack(item) {
+function enrichTrack(item, ordinal) {
   // spotify returns different structure for playlist and album tracks
   const track = item.track || item;
 
@@ -10,7 +10,7 @@ function enrichTrack(item) {
   // Replace / with | to avoid creating folders when creating mp3 files
   const name = track.name.replace(/\//g, "|");
 
-  const fullTitle = `${artists} - ${name}`;
+  const fullTitle = `${ordinal + 1}. ${artists} - ${name}`;
 
   return { ...track, fullTitle };
 }
@@ -48,8 +48,8 @@ export async function fetchPlaylist(spotifyId, options = { spotifyApi }) {
   });
 
   const tracks = [];
-  for (const item of items) {
-    tracks.push(enrichTrack(item));
+  for (let i = 0; i < items.length; i++) {
+    tracks.push(enrichTrack(items[i], i));
   }
 
   const folderName = getFolderName({ spotifyId, playlistDetails });


### PR DESCRIPTION
Attach track number in filename to keep same ordering
on devices that do not respect the ordinal tag.
