### PR TITLE
fix: ordinal in filenames to ensure order

### DIFF
--- a/src/services/spotify.js
+++ b/src/services/spotify.js
@@ -1,11 +1,12 @@
 import * as spotifyApi from "../api/spotify/spotify.js";
 import { getArtists } from "../utils/spotify.js";
+import { getOrdinalString } from "../utils/basic.js";
 
 function shouldPrefixWithOrdinal(type) {
   return type === "album" || type === "playlist";
 }
 
-function enrichTrack({ item, ordinal, type }) {
+function enrichTrack({ item, ordinal, totalLength, type }) {
   // spotify returns different structure for playlist and album tracks
   const track = item.track || item;
 
@@ -14,7 +15,9 @@ function enrichTrack({ item, ordinal, type }) {
   // Replace / with | to avoid creating folders when creating mp3 files
   const name = track.name.replace(/\//g, "|");
 
-  const prefix = shouldPrefixWithOrdinal(type) ? `${ordinal + 1}. ` : "";
+  const prefix = shouldPrefixWithOrdinal(type)
+    ? `${getOrdinalString(ordinal + 1, totalLength)}. `
+    : "";
   const fullTitle = `${prefix}${artists} - ${name}`;
 
   return { ...track, fullTitle };
@@ -55,7 +58,12 @@ export async function fetchPlaylist(spotifyId, options = { spotifyApi }) {
   const tracks = [];
   for (let i = 0; i < items.length; i++) {
     tracks.push(
-      enrichTrack({ item: items[i], ordinal: i, type: spotifyId.type })
+      enrichTrack({
+        item: items[i],
+        ordinal: i,
+        totalLength: items.length,
+        type: spotifyId.type,
+      })
     );
   }
 

--- a/src/utils/__tests__/basic.test.js
+++ b/src/utils/__tests__/basic.test.js
@@ -1,7 +1,12 @@
 import { describe, it, mock } from "node:test";
 import assert from "node:assert";
 import https from "node:https";
-import { titleToFriendlyName, delay, downloadImageToMemory } from "../basic.js";
+import {
+  titleToFriendlyName,
+  delay,
+  downloadImageToMemory,
+  getOrdinalString,
+} from "../basic.js";
 
 describe("basic.js utilities", () => {
   describe("titleToFriendlyName", () => {
@@ -127,6 +132,15 @@ describe("basic.js utilities", () => {
         mockError,
         "Function should reject with the network error"
       );
+    });
+  });
+
+  describe("getOrdinalString", () => {
+    it("should return a zero-padded ordinal string", () => {
+      assert.strictEqual(getOrdinalString(0, 1), "0");
+      assert.strictEqual(getOrdinalString(1, 2), "1");
+      assert.strictEqual(getOrdinalString(2, 3), "2");
+      assert.strictEqual(getOrdinalString(9, 10), "09");
     });
   });
 });

--- a/src/utils/basic.js
+++ b/src/utils/basic.js
@@ -59,3 +59,9 @@ export async function downloadImageToMemory(url) {
       .on("error", reject);
   });
 }
+
+export function getOrdinalString(ordinal, totalLength) {
+  const totalDigits = totalLength.toString().length;
+  const ordinalString = ordinal.toString().padStart(totalDigits, "0");
+  return ordinalString;
+}


### PR DESCRIPTION
This is required to ensure ordering for lists > 9 items.