### PR TITLE
feat: add thumbnail preview for YouTube track tagging

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,17 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(tree:*)",
+      "Bash(git remote get-url:*)",
+      "mcp__github__list_issues",
+      "Bash(cat:*)",
+      "Bash(ls:*)",
+      "Bash(curl:*)",
+      "Bash(chmod:*)"
+    ]
+  },
+  "enableAllProjectMcpServers": true,
+  "enabledMcpjsonServers": [
+    "github"
+  ]
+}

--- a/.cursor/commands/self-review.md
+++ b/.cursor/commands/self-review.md
@@ -2,6 +2,6 @@
 
 ## Overview
 
-I'm about to commit changes to the checkout flow. Review them for bugs, edge cases, and anything that might surprise a reviewer.
+I'm about to commit changes. Review them for bugs, edge cases, and anything that might surprise a reviewer. Feel free to ask any clarifications.
 
 What questions will reviewers have about these changes? What context should I include in the PR description?

--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ web_modules/
 
 # dotenv environment variable files
 .env
+.mcp.json
 .env.development.local
 .env.test.local
 .env.production.local
@@ -136,3 +137,6 @@ dist
 .yarn/build-state.yml
 .yarn/install-state.gz
 .pnp.*
+
+
+.cursor/mcp.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,127 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Spoti3 is a CLI tool that downloads songs from Spotify playlists/albums/tracks to MP3 format using YouTube as the source. It fetches playlist metadata from Spotify, searches for matching videos on YouTube, downloads them using yt-dlp, and tags the MP3 files with proper metadata.
+
+## Development Commands
+
+### Running the Application
+
+```bash
+# Download a playlist/album/track
+npm run start <spotify_url>
+
+# Debug mode with detailed logging
+npm run debug <spotify_url>
+```
+
+### Testing
+
+```bash
+# Run all tests (uses Node.js built-in test runner)
+npm test
+
+# Run tests in a specific file
+node --test src/utils/__tests__/basic.test.js
+```
+
+### Linting
+
+```bash
+# Run ESLint
+npm run lint
+```
+
+## Architecture Overview
+
+The codebase follows a layered architecture with clear separation of concerns:
+
+### Directory Structure
+
+- **`/src/cli`** - CLI entry point using Commander.js, parses arguments and routes to domain layer
+- **`/src/domain`** - Core business logic for downloading playlists/tracks, converting, and tagging
+- **`/src/services`** - Higher-level workflows that orchestrate API calls (Spotify playlist fetching, YouTube search)
+- **`/src/api`** - Low-level API clients (Spotify, YouTube)
+- **`/src/config`** - Configuration constants (API keys, app settings, download settings)
+- **`/src/store`** - Persistence layer for saving playlists to disk
+- **`/src/utils`** - Shared utility functions (logging, caching, file operations, validation)
+
+### Data Flow
+
+1. **CLI** (`src/cli/index.js`) receives user input and validates the URL
+2. **Services** (`src/services/index.js`) routes to appropriate service based on URL source (Spotify/YouTube)
+3. **API clients** fetch playlist metadata from Spotify API
+4. **Services** search YouTube for matching tracks for each song
+5. **Domain layer** (`src/domain/download/playlist.js`) orchestrates downloading each track:
+   - Calls yt-dlp via `downloadTrack()` to download MP3
+   - Tags MP3 files with metadata via `saveTrackTags()`
+6. Downloads are saved to `downloads/<playlist-name>/` folder
+
+### Key Modules
+
+**URL Validation** (`src/utils/validation.js`)
+
+- Validates and identifies source (Spotify vs YouTube)
+- Used at CLI entry point before fetching playlist
+
+**Playlist Fetching** (`src/services/spotify/index.js`, `src/services/youtube/index.js`)
+
+- Fetches playlist/album/track metadata from Spotify API
+- Searches YouTube API for each track to find matching videos
+- Returns normalized playlist object with track list
+
+**Track Downloading** (`src/domain/download/track.js`)
+
+- Executes yt-dlp command to download from YouTube
+- Handles file naming, folder structure
+
+**MP3 Tagging** (`src/domain/tag/index.js`)
+
+- Uses mp3tag.js to write ID3 tags (title, artist, album, track number, cover art)
+- Downloads cover art from Spotify and embeds into MP3
+
+## Configuration
+
+### Environment Variables
+
+Required API keys in `.env` (see `.env.sample`):
+
+- `SPOTIFY_CLIENT_ID` - From Spotify Developer Dashboard
+- `SPOTIFY_CLIENT_SECRET` - From Spotify Developer Dashboard
+- `YOUTUBE_API_KEY` - From Google Cloud Console (YouTube Data API v3)
+- `LOG_LEVEL` - Optional: debug, info, warn, error (default: info)
+
+### External Dependencies
+
+- **yt-dlp** - Must be installed globally, used to download audio from YouTube
+- **ffmpeg** - Required by yt-dlp for audio conversion to MP3
+
+## Testing Strategy
+
+Tests use Node.js built-in test runner (node:test). Test files are located:
+
+- `src/utils/__tests__/` - Utility function tests
+- `src/services/__tests__/` - Service layer integration tests
+- `src/services/spotify/*.test.js` - Spotify-specific tests co-located with implementation
+
+When adding new utility functions, add tests to existing test files in `__tests__` folders rather than creating new test files.
+
+## Coding Patterns
+
+- **Simplicity first** - Prefer simple solutions, avoid over-engineering
+- **No duplication** - Check for existing implementations before adding new code
+- **File size limit** - Keep files under 300 lines, refactor into smaller modules if needed
+- **Use existing packages** - Only use dependencies already in package.json
+- **ES Modules** - Project uses `"type": "module"` in package.json, use import/export syntax
+- **Minimal comments** - Use comments sparingly, only for complex code that isn't self-evident
+
+## Common Gotchas
+
+- **API Rate Limits**: YouTube API has daily quotas (~100 songs/day). Quota exceeded errors are handled via `QuotaExceededError` in `src/domain/errors.js`
+- **Signal Handling**: The download loop handles SIGINT (Ctrl+C) gracefully in `src/domain/download/playlist.js`
+- **Track Matching**: YouTube search may not always find the exact song. The matching logic is in `src/services/youtube/index.js`
+- **API Caching**: API responses are cached in `.cache/` directory to avoid repeated calls during development
+- **Spotify Playlists**: Some Spotify-curated playlists may not be downloadable due to API restrictions

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "test": "NODE_ENV=test node --test",
     "start": "node src/cli/index.js mp3",
-    "debug": "LOG_LEVEL=debug MOCK_DOWNLOAD=yes node --inspect src/cli/index.js mp3",
+    "debug": "LOG_LEVEL=debug node --inspect src/cli/index.js mp3",
     "lint": "eslint ."
   },
   "keywords": [

--- a/src/api/spotify/index.js
+++ b/src/api/spotify/index.js
@@ -196,7 +196,7 @@ export async function fetchSingleTrack({ accessToken, spotifyId }) {
  * @param {object} options Options object
  * @param {string} options.accessToken Spotify access token (required)
  * @param {boolean} options.disableCache Disable cache (default: false)
- * @returns {object|null} { artist: string, title: string } or null if not found
+ * @returns {object|null} { artist: string, title: string, thumbnails: Array } or null if not found
  */
 export async function searchTrack(query, options = {}) {
   const { accessToken, disableCache: optDisableCache } = options;
@@ -251,12 +251,14 @@ export async function searchTrack(query, options = {}) {
       ? track.artists.map((a) => a.name).join(", ")
       : "";
     const title = track.name || "";
+    const thumbnails = track.album?.images || [];
 
     logger.debug(`Found track on Spotify: ${artist} - ${title}`);
 
     const result = {
       artist,
       title,
+      thumbnails,
       found: true,
     };
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -43,7 +43,6 @@ program
   .command("mp3")
   .description("Downloads a tracklist into mp3 files from YouTube")
   .argument("<url>", "the Spotify playlist/track URL")
-  .option("-m, --mock", "do not download the files")
   .option(
     "-a, --album-tag",
     "set album name in mp3 files, will override default album name"

--- a/src/domain/download/track.js
+++ b/src/domain/download/track.js
@@ -9,7 +9,6 @@ import {
   displayImageInTerminal,
 } from "../../utils/basic.js";
 import { mp3 } from "../convert/index.js";
-import { delay } from "../../utils/basic.js";
 import { setTags } from "../tag/index.js";
 import { getFileName } from "../../utils/file.js";
 import {
@@ -108,12 +107,6 @@ export async function downloadTrack({ playlist, track, downloadOptions }) {
     process.chdir(playlistFolder);
 
     logger.debug(`Downloading ${getFileName(trackFilename)}...`);
-
-    if (process.env.MOCK_DOWNLOAD === "yes" || downloadOptions?.mock) {
-      await delay(300);
-      logger.debug(`Mocked download of ${getFileName(trackFilename)}`);
-      return { outcome: "SUCCESS", mp3File: trackFilename };
-    }
 
     mp3(track.fullTitle, videoId);
 

--- a/src/domain/download/track.js
+++ b/src/domain/download/track.js
@@ -163,14 +163,11 @@ export async function saveTrackTags(track, playlist, tagOptions, artBytes) {
     // Prompt user to confirm the artist / title when it comes from YouTube
     if (track.videoId && logger.prompt && typeof logger.prompt === "function") {
       // Determine prompt text based on tag source
-      const artistPromptText =
-        tagSource === "spotify"
-          ? "Artist (Tag source=Spotify): "
-          : "Artist (Tag source=Youtube): ";
-      const titlePromptText =
-        tagSource === "spotify"
-          ? "Title (Tag source=Spotify): "
-          : "Title (Tag source=Youtube): ";
+      const artistPromptText = `Artist (source: ${tagSource})`;
+      const titlePromptText = `Title (source: ${tagSource})`;
+      const thumbnailPromptText = track.thumbnails
+        ? `Thumbnail (source: ${tagSource})`
+        : null;
 
       const confirmedArtist = await logger.prompt(artistPromptText, {
         placeholder: "Not sure",
@@ -199,7 +196,7 @@ export async function saveTrackTags(track, playlist, tagOptions, artBytes) {
             "Thumbnail preview not available (use iTerm2/Kitty/WezTerm)"
           );
         }
-        const approvedThumbnail = await logger.prompt("Use this thumbnail?", {
+        const approvedThumbnail = await logger.prompt(thumbnailPromptText, {
           type: "confirm",
           initial: true,
         });

--- a/src/utils/basic.js
+++ b/src/utils/basic.js
@@ -65,3 +65,55 @@ export function getOrdinalString(ordinal, totalLength) {
   const ordinalString = ordinal.toString().padStart(totalDigits, "0");
   return ordinalString;
 }
+
+/**
+ * Checks if the current terminal supports inline images (iTerm2, Kitty, WezTerm)
+ *
+ * @returns {boolean} True if terminal supports inline images
+ */
+export function supportsInlineImages() {
+  const termProgram = process.env.TERM_PROGRAM || "";
+  const term = process.env.TERM || "";
+
+  // iTerm2 sets TERM_PROGRAM to "iTerm.app"
+  if (termProgram === "iTerm.app") return true;
+
+  // WezTerm sets TERM_PROGRAM to "WezTerm"
+  if (termProgram === "WezTerm") return true;
+
+  // Kitty sets TERM to "xterm-kitty"
+  if (term === "xterm-kitty") return true;
+
+  return false;
+}
+
+/**
+ * Displays an image in the terminal using iTerm2 inline images protocol
+ * Works in iTerm2, Kitty, WezTerm, and other compatible terminals
+ * Returns false if terminal doesn't support inline images
+ *
+ * @param {Buffer|Uint8Array} imageData - The image data as a buffer
+ * @param {Object} options - Display options
+ * @param {number} options.size - Size in characters for display (default: 20)
+ * @returns {boolean} True if image was displayed, false otherwise
+ */
+export function displayImageInTerminal(imageData, options = {}) {
+  if (!supportsInlineImages()) {
+    return false;
+  }
+
+  const { size = 20 } = options;
+
+  const base64Data = Buffer.from(imageData).toString("base64");
+
+  // Build iTerm2 inline image escape sequence
+  const params = `inline=1;width=${size}`;
+
+  // OSC 1337 ; File=[params]:[base64 data] BEL
+  const escapeSequence = `\x1b]1337;File=${params}:${base64Data}\x07`;
+
+  process.stdout.write(escapeSequence);
+  process.stdout.write("\n");
+
+  return true;
+}

--- a/src/utils/cache.js
+++ b/src/utils/cache.js
@@ -15,15 +15,15 @@ function ensureCacheDir() {
 }
 
 /**
- * Get the cache file path for a YouTube ID
+ * Get the cache file path for an ID object (YouTube or Spotify)
  *
- * @param {object} youtubeId { type: string, value: string }
+ * @param {object} id { type: string, value: string }
  * @param {string} suffix Optional suffix to differentiate cache types (e.g., 'details', 'tracks')
  * @returns {string} Cache file path
  */
-export function getCachePath(youtubeId, suffix = "") {
+export function getCachePath(id, suffix = "") {
   ensureCacheDir();
-  const { type, value } = youtubeId;
+  const { type, value } = id;
   const filename = suffix
     ? `${type}_${value}_${suffix}.json`
     : `${type}_${value}.json`;


### PR DESCRIPTION
## Summary

This PR adds thumbnail preview functionality for YouTube track tagging, allowing users to see and approve thumbnails in the terminal before they are applied.

## Changes

- Add thumbnail preview display in terminal for YouTube tracks
- Add caching layer for Spotify API to improve performance
- Add CLAUDE.md for AI-assisted development documentation

## Closes

Closes #35